### PR TITLE
Fix format check in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,6 @@ jobs:
         with:
           node-version: "21.x"
       - run: yarn install
-      - run: yarn format
       - run: yarn format:check
 
   test:


### PR DESCRIPTION
Remove yarn format so the format:check runs
<img width="1124" alt="Screenshot 2024-11-12 at 7 34 25 AM" src="https://github.com/user-attachments/assets/71670775-b218-405a-9617-90cc1485b98a">
